### PR TITLE
Fix for whitespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl module Text::Hogan
 
+1.02 2016-02-29
+    * Add allow_whitespace_before_hashmark feature
+
 1.01 2015-07-13
     * Add numeric_string_as_string feature
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name                = Text-Hogan
-version             = 1.01
+version             = 1.02
 abstract            = Text::Hogan - A mustache templating engine statement-for-statement cloned from hogan.js
 
 author              = Alex Balhatchet

--- a/lib/Text/Hogan/Compiler.pm
+++ b/lib/Text/Hogan/Compiler.pm
@@ -122,7 +122,7 @@ sub scan {
     };
 
     if ($options->{'delimiters'}) {
-        $delimiters = [ split ' ', $options->{'delimiters'} ];
+        my $delimiters = [ split ' ', $options->{'delimiters'} ];
         $otag = $delimiters->[0];
         $ctag = $delimiters->[1];
     }

--- a/lib/Text/Hogan/Compiler.pm
+++ b/lib/Text/Hogan/Compiler.pm
@@ -145,6 +145,7 @@ sub scan {
         }
         elsif ($state eq $IN_TAG_TYPE) {
             $i += length($otag) - 1;
+            $i += 1 while(char_at($text, $i+1) eq ' ');
             $tag = $tags{char_at($text,$i + 1)};
             $tag_type = $tag ? char_at($text, $i + 1) : '_v';
             if ($tag_type eq '=') {

--- a/lib/Text/Hogan/Compiler.pm
+++ b/lib/Text/Hogan/Compiler.pm
@@ -32,7 +32,7 @@ sub new {
 }
 
 sub scan {
-    my ($self, $text, $delimiters) = @_;
+    my ($self, $text, $options) = @_;
 
     my $len = length $text;
     my ($IN_TEXT, $IN_TAG_TYPE, $IN_TAG) = (0, 1, 2);
@@ -121,8 +121,8 @@ sub scan {
         return $close_index + length($close) - 1;
     };
 
-    if ($delimiters) {
-        $delimiters = [ split ' ', $delimiters ];
+    if ($options->{'delimiters'}) {
+        $delimiters = [ split ' ', $options->{'delimiters'} ];
         $otag = $delimiters->[0];
         $ctag = $delimiters->[1];
     }
@@ -145,7 +145,7 @@ sub scan {
         }
         elsif ($state eq $IN_TAG_TYPE) {
             $i += length($otag) - 1;
-            $i += 1 while(char_at($text, $i+1) eq ' ');
+            $i += 1 while($options->{'allow_whitespace_before_hashmark'} and (char_at($text, $i+1) eq ' '));
             $tag = $tags{char_at($text,$i + 1)};
             $tag_type = $tag ? char_at($text, $i + 1) : '_v';
             if ($tag_type eq '=') {
@@ -520,7 +520,7 @@ my %cache;
 
 sub cache_key {
     my ($text, $options) = @_;
-    return join("||", $text, !!$options->{'as_string'}, !!$options->{'numeric_string_as_string'}, !!$options->{'disable_lambda'}, ($options->{'delimiters'} || ""));
+    return join("||", $text, !!$options->{'as_string'}, !!$options->{'numeric_string_as_string'}, !!$options->{'disable_lambda'}, ($options->{'delimiters'} || ""), ($options->{'allow_whitespace_before_hashmark'} || 0));
 }
 
 sub compile {
@@ -542,7 +542,7 @@ sub compile {
 
     $template = $self->generate(
         $self->parse(
-            $self->scan($text, $options->{'delimiters'}), $text, $options
+            $self->scan($text, $options), $text, $options
         ), $text, $options
     );
 

--- a/lib/Text/Hogan/Compiler.pm
+++ b/lib/Text/Hogan/Compiler.pm
@@ -587,12 +587,18 @@ Takes template text and returns an arrayref which is a list of tokens.
 
     my $tokens = $compiler->scan("Hello, {{name}}!");
 
-Optionally takes a string which represents different delimiters, split by
-white-space. You should never need to pass this directly, it it used to
-implement the in-template delimiter-switching functionality.
+Optionally takes a hashref with options. 'delimiters' is a string which
+represents different delimiters, split by white-space. You should never
+need to pass this directly, it it used to implement the in-template
+delimiter-switching functionality.
 
     # equivalent to the above call with mustaches
-    my $tokens = Text::Hogan::Compiler->new->scan("Hello, <% name %>!", "<% %>")
+    my $tokens = Text::Hogan::Compiler->new->scan("Hello, <% name %>!", { delimiters => "<% %>" });
+
+'allow_whitespace_before_hashmark' is a boolean. If true,tags are allowed
+to have space(s) between the delimiters and the opening sigil ('#', '/', '^', '<', etc.).
+
+	my $tokens = Text::Hogan::Compiler->new->scan("Hello{{ # foo }}, again{{ / foo }}.", { allow_whitespace_before_hashmark => 1 });
 
 =head2 parse
 
@@ -644,15 +650,14 @@ you the Text::Hogan::Template object.
 Also caches templates by a sensible cache key, which can be useful if you're
 not stringifying and storing on disk or in memory anyway.
 
-Optionally takes a hashref that will be passed on to parse and generate. If the
-hashref has a key called "delimiters" then that key's value only will be passed
-to scan.
+Optionally takes a hashref that will be passed on to scan, parse, and generate.
 
     my $perl_code_as_string = $compiler->compile(
         $text,
         {
             delimiters => "<% %>",
             as_string => 1,
+            allow_whitespace_before_hashmark => 1,
         },
     );
 

--- a/t/synopsis_text_hogan_compiler.t
+++ b/t/synopsis_text_hogan_compiler.t
@@ -17,5 +17,17 @@ my $template = $compiler->generate($tree, $text);
 
 is $template->render({ name => "Alex" }), "Hello, Alex!", "Text::Hogan::Compiler synopsis works";
 
+# whitespace testing
+my $ws_template = '{{ # foo }}do not render if whitespace allowed{{ / foo }}';
+my $ws_data = { foo => 0 };
+
+my $ws_compiler = Text::Hogan::Compiler->new();
+
+is $ws_compiler->compile( $ws_template, { 'allow_whitespace_before_hashmark' => 0 } )->render($ws_data),
+  "do not render if whitespace allowed",
+  "Text::Hogan::Compiler doesn't allow whitespace between delimeters and tag type ...";
+is $ws_compiler->compile( $ws_template, { 'allow_whitespace_before_hashmark' => 1 } )->render($ws_data),
+  "",
+  "... unless specified in the options";
 
 done_testing();


### PR DESCRIPTION
Hi! Re #1, this fix allows the addition of spaces (and only spaces) between the opening delimiters and the initial sigil. I've updated the documentation and added a test as well. This is an optional behavior, so in order to pass the option, I had to make the `scan` function take the entire options array.
