### PR TITLE
Performance tweaks, upgrades

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,13 +8,14 @@ copyright_holder    = Alex Balhatchet
 
 [Prereqs / RuntimeRequires]
 Clone        = 0.37
+HTML::Escape = 1.11
 Ref::Util    = 0.204
 Scalar::Util = 1.41
 Text::Trim   = 1.02
 
 [Prereqs / TestRequires]
 Test::More = 1.001008
-YAML       = 1.13
+YAML::XS   = 0.67
 Data::Visitor::Callback = 0.30
 Try::Tiny = 0.22
 Path::Tiny = 0.059

--- a/lib/Text/Hogan/Template.pm
+++ b/lib/Text/Hogan/Template.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Clone qw(clone);
+use HTML::Escape qw(escape_html);
 use Ref::Util qw( is_ref is_arrayref is_coderef is_hashref);
 use Scalar::Util qw(looks_like_number);
 
@@ -34,23 +35,9 @@ sub r {
     return "";
 }
 
-my %mapping = ( 
-    '&' => '&amp;',
-    '<' => '&lt;',
-    '>' => '&gt;',
-    q{'} => '&#39;',
-    '"' => '&quot;',
-);
-
-# create regex once
-my $mapping_re = join('', '[', ( sort keys %mapping ), ']');
-
 sub v {
     my ($self, $str) = @_;
-    $str //= "";
-    $str =~ s/($mapping_re)/$mapping{$1}/ge;
-
-    return $str;
+    return escape_html($str // "");
 }
 
 sub t {
@@ -313,7 +300,7 @@ sub sub {
 sub find_in_scope {
     my ($key, $scope) = @_;
 
-    return eval { $scope->{$key} };
+    return is_hashref($scope) ? $scope->{$key} : undef;
 }
 
 sub create_specialized_partial {

--- a/t/spec_test.t
+++ b/t/spec_test.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 
-use YAML;
+use YAML::XS qw(Load);
 use Path::Tiny;
 use Try::Tiny;
 use Data::Visitor::Callback;
@@ -36,9 +36,9 @@ my $data_fixer = Data::Visitor::Callback->new(
 my @spec_files = path("t", "specs")->children(qr/[.]yml$/);
 
 for my $file (sort @spec_files) {
-    my $yaml = $file->slurp_utf8;
+    my $yaml = $file->slurp;
 
-    my $specs = YAML::Load($yaml);
+    my $specs = Load($yaml);
 
     note "----- $file ", ("-" x (70-length($file)));
 


### PR DESCRIPTION
- Replace eval{} in find_in_scope with explicit is_hashref check for faster, error-surfacing variable lookup
- Replace hand-rolled HTML escaping regex with HTML::Escape (XS-backed)
- Replace YAML with YAML::XS in test suite for faster, robust YAML parsing. (YAML docs recomend instead using YAML::XS)